### PR TITLE
chore: update .NET SDK and dependencies to 10.0.103

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.102",
+    "version": "10.0.103",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/src/Chronicle/Chronicle.csproj
+++ b/src/Chronicle/Chronicle.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
-    <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.22.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="all" />
+    <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.23.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- global.json: SDK 10.0.102 → 10.0.103
- Microsoft.Extensions.* (Http, Logging.Abstractions, Logging.Console): 10.0.2 → 10.0.3
- Spectre.Console.Cli.Extensions.DependencyInjection: 0.22.0 → 0.23.0
- Microsoft.SourceLink.GitHub: 10.0.102 → 10.0.103